### PR TITLE
[FIX] 페이지 이동시 비동기 문제 해결

### DIFF
--- a/src/components/Past.js
+++ b/src/components/Past.js
@@ -1,39 +1,53 @@
 import Card from "./common/Card.js";
 
-// [x] 과거 데이터 추가 
-  // [x] Upcoming 컴포넌트와 비슷하므로 참고하여 작업
-  // [x] api 호출 순서 확인
-  // [x] 실제 응답 확인
-  // [x] api 가공
-  // [x] 10개만 요청, 더보기 클릭시 추가 요청
-  // [x] Upcoming 하단에 추가 
-  // [x] 상단에 링크 태그 생성
-  // [x] style 적용
-async function Past() {
+// 문제
+  // 컴포넌트자체가 비동기이다. 
+  // router에서는 컴포넌트가 fulfilled가 될때까지 기다렸다 렌더링한다.
+  
+  // **기존 router순서**
+  // 기존 dom을 지우고 
+  // 컴포넌트의 비동기요청이 완료되고 template이 완성되면 
+  // dom에 mount한다. 
+  
+  // **문제 발생**
+  // 비동기 요청이 완료되지 않았을 때 페이지를 이동한다면 
+  // 기존 페이지에 추가로 append하게 된다.
+
+// 해결
+  // router함수를 동기함수로 바꾸고
+  // 비동기 컴포넌트를 동기로 바꾸고 
+  // 비동기 요청에 관한 로직은
+  // 'componentDidMount' 함수에 담고 실행한다.
+  // 비동기 로직은 요청하고 즉시 종료되고
+  // 컴포넌트는 html 요소를 반환한다.
+  // componentDidMount함수는 해당 컴포넌트 요소를 
+  // '클로저'로 갖는다.
+  // 비동기 요청이 완료되면 해당 컴포넌트의 요소에 mount한다.
+function Past() {
   const $wrapper = document.createElement('section');
   $wrapper.setAttribute('id', 'Past');
 
-  // past 데이터 얻고
-  const past = await getPast();
-
-  // 최신 10개만 
-  // rocket 이미지 url 합치기
-  let i = 10;
-  while(i--) {
-    const rocket = past[past.length -1 - i].rocket;
-    past[past.length -1 - i].rocket_img = await getRocketImg(rocket);
-  }
-
-  const cards = [];
-  for(let j = 0; j < 10; j++) {
-    cards.push(Card(past[past.length - 1 - j]));
-  }
-  
   const template = `
     <h1>Past.</h1>
   `;
   $wrapper.innerHTML = template;
-  $wrapper.append(...cards);
+
+  const componentDidMounted = async () => {
+    const past = await getPast();
+  
+    let i = 10;
+    while(i--) {
+      const rocket = past[past.length -1 - i].rocket;
+      past[past.length -1 - i].rocket_img = await getRocketImg(rocket);
+    }
+  
+    const cards = [];
+    for(let j = 0; j < 10; j++) {
+      cards.push(Card(past[past.length - 1 - j]));
+    }
+    $wrapper.append(...cards);
+  }
+  componentDidMounted();
 
   return $wrapper;
 };

--- a/src/components/UpComing.js
+++ b/src/components/UpComing.js
@@ -1,24 +1,26 @@
 import Card from "./common/Card.js";
 
-async function UpComing() {
+function UpComing() {
   const $wrapper = document.createElement('section');
   $wrapper.setAttribute('id', 'UpComing');
 
-  // upcoming데이터 얻고
-  const upcoming = await getUpcoming();
-
-  // rocket 이미지 url 합치기
-  for (let i = 0; i < upcoming.length; i++) {
-    const rocket = upcoming[i].rocket;
-    upcoming[i].rocket_img = await getRocketImg(rocket);
-  }
-  const cards = upcoming.map(obj => Card(obj)); // [element, ...]
-  
   const template = `
     <h1>Upcoming.</h1>
   `;
   $wrapper.innerHTML = template;
-  $wrapper.append(...cards);
+
+  const componentDidMounted = async () => {
+    const upcoming = await getUpcoming();
+    
+    for (let i = 0; i < upcoming.length; i++) {
+      const rocket = upcoming[i].rocket;
+      upcoming[i].rocket_img = await getRocketImg(rocket);
+    }
+
+    const cards = upcoming.map(obj => Card(obj)); // [element, ...]
+    $wrapper.append(...cards);
+  }
+  componentDidMounted();
 
   return $wrapper;
 };

--- a/src/pages/News.js
+++ b/src/pages/News.js
@@ -5,7 +5,7 @@ import Moves from "../components/common/Moves.js";
 
 import { $ } from '../utils/dom.js';
 
-async function News() {
+function News() {
   const $wrapper = document.createElement('div');
   $wrapper.setAttribute('id', 'NewsPage');
   
@@ -14,8 +14,8 @@ async function News() {
     Moves()
   );
   $wrapper.append(
-    await UpComing(),
-    await Past()
+    UpComing(),
+    Past()
   );
 
   return $wrapper;

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -9,13 +9,13 @@ export const routes = [
   { path: /^\/$/, component: Landing },
   { path: /^\/news$/, component: News}
 ];
-export const router = async (routes, path) => {
+export const router = (routes, path) => {
   const component = routes
     .find(route => route.path.test(path))
     ?.component || NotFound;
   
   $('#root').innerHTML = '';
-  $('#root').append(await component());
+  $('#root').append(component());
 };
 export const navigate = path => e => {
   if (path) {


### PR DESCRIPTION
# Implementations
## 문제
  컴포넌트자체가 비동기이다. 
  router에서는 컴포넌트가 fulfilled가 될때까지 기다렸다 렌더링한다.

  **기존 router순서**
  기존 dom을 지우고 
  컴포넌트의 비동기요청이 완료되고 template이 완성되면 
  dom에 mount한다. 

   **문제 발생**
  비동기 요청이 완료되지 않았을 때 페이지를 이동한다면 
  기존 페이지에 추가로 append하게 된다.

## 해결
  router함수를 동기함수로 바꾸고
  비동기 컴포넌트를 동기로 바꾸고 
  비동기 요청에 관한 로직은
  'componentDidMount' 함수에 담고 실행한다.
  비동기 로직은 요청하고 즉시 종료되고
  컴포넌트는 html 요소를 반환한다.
  componentDidMount함수는 해당 컴포넌트 요소를 
  '클로저'로 갖는다.
  비동기 요청이 완료되면 해당 컴포넌트의 요소에 mount한다.

# ScreenShoots
<img width='70%' src='https://user-images.githubusercontent.com/87258182/190857938-d1b51449-281a-4538-84f2-4d55e24ce2ab.gif'>
