### PR TITLE
[FEAT] past컴포넌트 infinite scroll 구현

### DIFF
--- a/src/components/Past.js
+++ b/src/components/Past.js
@@ -1,30 +1,11 @@
+import { get, BASE_URL, getRocketImg } from "../utils/api.js";
 import { $ } from "../utils/dom.js";
+
 import Card from "./common/Card.js";
 import Loading from "./common/Loading.js";
 
-// 문제
-  // 컴포넌트자체가 비동기이다. 
-  // router에서는 컴포넌트가 fulfilled가 될때까지 기다렸다 렌더링한다.
-  
-  // **기존 router순서**
-  // 기존 dom을 지우고 
-  // 컴포넌트의 비동기요청이 완료되고 template이 완성되면 
-  // dom에 mount한다. 
-  
-  // **문제 발생**
-  // 비동기 요청이 완료되지 않았을 때 페이지를 이동한다면 
-  // 기존 페이지에 추가로 append하게 된다.
-
-// 해결
-  // router함수를 동기함수로 바꾸고
-  // 비동기 컴포넌트를 동기로 바꾸고 
-  // 비동기 요청에 관한 로직은
-  // 'componentDidMount' 함수에 담고 실행한다.
-  // 비동기 로직은 요청하고 즉시 종료되고
-  // 컴포넌트는 html 요소를 반환한다.
-  // componentDidMount함수는 해당 컴포넌트 요소를 
-  // '클로저'로 갖는다.
-  // 비동기 요청이 완료되면 해당 컴포넌트의 요소에 mount한다.
+// [x] 모든 데이터 요청시 응답시간 체크
+// [ ] 10개 단위로 요청 
 function Past() {
   const $wrapper = document.createElement('section');
   $wrapper.setAttribute('id', 'Past');
@@ -34,23 +15,33 @@ function Past() {
   `;
   $wrapper.innerHTML = template;
 
+    // 문제 
+    // 요청이 완료된 후 다음 요청을 하므로 
+    // 요청(1) -> 요청 완료 -> 요청(2) -> 요청 완료 -> 요청(3) ...ing
+    // 약 200개의 요청에 대해 약 3.3초가 걸림
+
+    // 해결
+    // Promise.allSettled 사용하자
+    // Promise.allSettled([ P1, p2, ... ])
+    // 약 200개의 요청에 대해 약 1.5초가 걸림
+
+      // ==> 약 2배의 응답 속도 증가
   const componentDidMounted = async () => {
     $wrapper.append(Loading());
+    
+    const past = await get(`${ BASE_URL }/v5/launches/past`);
+    past.reverse();
+    const rocket_img_urls = past.map(obj => getRocketImg(obj.rocket));
+    const prepared_rocket_img_urls = await Promise.allSettled(rocket_img_urls);
 
-    const past = await getPast();
-  
-    let i = 10;
-    while(i--) {
-      const rocket = past[past.length -1 - i].rocket;
-      past[past.length -1 - i].rocket_img = await getRocketImg(rocket);
-    }
-  
-    const cards = [];
-    for(let j = 0; j < 10; j++) {
-      cards.push(Card(past[past.length - 1 - j]));
-    }
+    prepared_rocket_img_urls.forEach((obj, i) => { 
+      past[i].rocket_img = obj.value;
+    });
+
+    const cards = past.map(obj => Card(obj)); // [element, ...]
 
     if ($('#Loading')) $('#Loading').remove();
+
     $wrapper.append(...cards);
   }
   componentDidMounted();
@@ -59,24 +50,3 @@ function Past() {
 };
 
 export default Past;
-
-// 날짜별 오름차순으로 보내줌
-// 내림차순으로 10개 뽑고 싶음 
-// for문으로 뒤에서 부터 열개 뽑자
-// upcoming과 데이터 형식은 동일
-
-// TODO 에러 처리 추가해서 재사용 가능
-const getPast = async () => {
-  const upcoming = await fetch('https://api.spacexdata.com/v5/launches/past')
-    .then(res => res.json()); 
-  return upcoming;
-}
-// TODO 재사용 가능 
-const getRocketImg = async roketId => {
-  const rocketAPI = 'https://api.spacexdata.com/v4/rockets/';
-  const rocketImg = await fetch(rocketAPI + roketId)
-    .then(res => res.json())
-    .then(res => res.flickr_images[1]);
-
-  return rocketImg;
-}

--- a/src/components/Past.js
+++ b/src/components/Past.js
@@ -1,9 +1,13 @@
 import { get, BASE_URL, getRocketImg } from "../utils/api.js";
 import { $ } from "../utils/dom.js";
+import { isItLast, isItRightPage, isItBottom} from '../utils/index.js';
+import { appendLastMent } from "../utils/dom.js";
 
 import Card from "./common/Card.js";
 import Loading from "./common/Loading.js";
 
+// 리팩토링
+// [x] 로직 분리
 function Past() {
   const $wrapper = document.createElement('section');
   $wrapper.setAttribute('id', 'Past');
@@ -13,35 +17,16 @@ function Past() {
   `;
   $wrapper.innerHTML = template;
 
-  // 무한 스크롤 구현
-  // [x] 초기 10개 요청
-  // [x] 스크롤 바닥 닿는 이벤트 생성
-  // [x] 스크롤이 바닥에 닿게 되면 10개의 아이템을 볼러온다.
-  // [x] 10개의 아이템을 불러오는 시간동안 로딩 UI를 띄운다.
-  // [x] 아이템이 다 불러와지면 로딩 컴포넌트를 지운다. 
-  // [x] 아이템이 다 불러와지면 무한 스크롤은 멈추게 된다. 
-
-  // 순서
-  // 10개씩 데이터 불러와야 하니깐 
-  // 어디까지 불러왔는지 page 저장 변수 필요하고
-  // -> sessionStorage 사용 
-
-  // 다음 페이지부터
-  // past를 10개 단위로 img_url 가져오고
-  // page++ 시키고
-  // past에 로켓 주소 붙이고
-  // Cards 컴포넌트 호출해서
-  // 기존 element에 append 하기
   const componentDidMounted = async () => {
     $wrapper.append(Loading());
 
     const past = await get(`${ BASE_URL }/v5/launches/past`);
+    
     past.reverse();
 
     if ($('#Loading')) $('#Loading').remove();
 
-    mountTenItmems(past)(1, $wrapper);
-    
+    mountTenItems(past)(1, $wrapper);
     sessionStorage.setItem('past', JSON.stringify(past));
     sessionStorage.setItem('page', 2);
   }
@@ -52,62 +37,55 @@ function Past() {
 
 export default Past;
 
-window.addEventListener('scroll',()=> {
-  if (!$('#Past')) return;
-	const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
-  
-  if (scrollTop + clientHeight > scrollHeight - 1) {
-    const $target = $('#Past');
+const getInfinitePast = async () => {
+  const $target = $('#Past');
     let page = Number(sessionStorage.getItem('page'));
     const past = JSON.parse(sessionStorage.getItem('past'));
 
-    if (page * 10 > past.length){
-      if ($('.last-page')) return;
-
-      const $last = document.createElement('div');
-      $last.classList.add('last-page');
-      $last.innerText = '더 이상 데이터가 없습니다.';
-      $target.append($last);
-
+    if (isItLast(page, past)) {
+      appendLastMent($target);
       return;
-    };
-
-    mountTenItmems(past)(page, $target);
-
-    sessionStorage.setItem('page', ++page);
-	}
-});
-
-const mountTenItmems = past => async (page, $target) => {
+    } 
+    await mountTenItems(past)(page, $target)
     
-  // 로딩 컴포넌트 mount
-  if(!$('#Loading'))  $target.append(Loading());
-
-  // 요청갯수 확인
+    sessionStorage.setItem('page', ++page);
+}
+const getTenLocketImg = (past, page) => {
   const requestMaxLength = past.length;
-  const rocket_img_urls = []; 
+  const res = []; 
   for (let i = (page - 1) * 10; i < page * 10; i++ ) {
     if (requestMaxLength <= i) break;
-
+    
     const rocket_img_url = getRocketImg(past[i].rocket);
-    rocket_img_urls.push(rocket_img_url);
+    res.push(rocket_img_url);
   }
-
-  // 결합 하는 부분
-  const prepared_rocket_img_urls = await Promise.allSettled(rocket_img_urls); 
+  return res;
+}
+const mergeRocketImg = async (past, img_urls, page) => {
+  const prepared_rocket_img_urls = await Promise.allSettled(img_urls); 
   prepared_rocket_img_urls.forEach((obj, i) => { 
     past[(page - 1) * 10 + i].rocket_img = obj.value;
   });
-
+}
+const mountTenItems = past => async (page, $target) => {
+  // 로딩 컴포넌트 mount
+  if(!$('#Loading')) $target.append(Loading());
+  // 10개 단위 요청
+  const rocket_img_urls = getTenLocketImg(past, page);
+  // 결합 하는 부분
+  await mergeRocketImg(past, rocket_img_urls, page);
   // cards 컴포넌트 만드는 부분
   let cards = [];
   for (let i = (page - 1) * 10; i < page * 10; i++) {
     cards.push(Card(past[i]));
   }
-
   // 로딩 컴포넌트 unmount
   if ($('#Loading')) $('#Loading').remove();
-
   // mount 하는 부분
   $target.append(...cards);
 }
+window.addEventListener('scroll', ()=> {
+  if (!isItRightPage('#Past')) return;
+
+  if (isItBottom()) getInfinitePast();
+});

--- a/src/components/Past.js
+++ b/src/components/Past.js
@@ -4,8 +4,6 @@ import { $ } from "../utils/dom.js";
 import Card from "./common/Card.js";
 import Loading from "./common/Loading.js";
 
-// [x] 모든 데이터 요청시 응답시간 체크
-// [ ] 10개 단위로 요청 
 function Past() {
   const $wrapper = document.createElement('section');
   $wrapper.setAttribute('id', 'Past');
@@ -15,34 +13,37 @@ function Past() {
   `;
   $wrapper.innerHTML = template;
 
-    // 문제 
-    // 요청이 완료된 후 다음 요청을 하므로 
-    // 요청(1) -> 요청 완료 -> 요청(2) -> 요청 완료 -> 요청(3) ...ing
-    // 약 200개의 요청에 대해 약 3.3초가 걸림
+  // 무한 스크롤 구현
+  // [x] 초기 10개 요청
+  // [x] 스크롤 바닥 닿는 이벤트 생성
+  // [x] 스크롤이 바닥에 닿게 되면 10개의 아이템을 볼러온다.
+  // [x] 10개의 아이템을 불러오는 시간동안 로딩 UI를 띄운다.
+  // [x] 아이템이 다 불러와지면 로딩 컴포넌트를 지운다. 
+  // [x] 아이템이 다 불러와지면 무한 스크롤은 멈추게 된다. 
 
-    // 해결
-    // Promise.allSettled 사용하자
-    // Promise.allSettled([ P1, p2, ... ])
-    // 약 200개의 요청에 대해 약 1.5초가 걸림
+  // 순서
+  // 10개씩 데이터 불러와야 하니깐 
+  // 어디까지 불러왔는지 page 저장 변수 필요하고
+  // -> sessionStorage 사용 
 
-      // ==> 약 2배의 응답 속도 증가
+  // 다음 페이지부터
+  // past를 10개 단위로 img_url 가져오고
+  // page++ 시키고
+  // past에 로켓 주소 붙이고
+  // Cards 컴포넌트 호출해서
+  // 기존 element에 append 하기
   const componentDidMounted = async () => {
     $wrapper.append(Loading());
-    
+
     const past = await get(`${ BASE_URL }/v5/launches/past`);
     past.reverse();
-    const rocket_img_urls = past.map(obj => getRocketImg(obj.rocket));
-    const prepared_rocket_img_urls = await Promise.allSettled(rocket_img_urls);
-
-    prepared_rocket_img_urls.forEach((obj, i) => { 
-      past[i].rocket_img = obj.value;
-    });
-
-    const cards = past.map(obj => Card(obj)); // [element, ...]
 
     if ($('#Loading')) $('#Loading').remove();
 
-    $wrapper.append(...cards);
+    mountTenItmems(past)(1, $wrapper);
+    
+    sessionStorage.setItem('past', JSON.stringify(past));
+    sessionStorage.setItem('page', 2);
   }
   componentDidMounted();
 
@@ -50,3 +51,63 @@ function Past() {
 };
 
 export default Past;
+
+window.addEventListener('scroll',()=> {
+  if (!$('#Past')) return;
+	const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
+  
+  if (scrollTop + clientHeight > scrollHeight - 1) {
+    const $target = $('#Past');
+    let page = Number(sessionStorage.getItem('page'));
+    const past = JSON.parse(sessionStorage.getItem('past'));
+
+    if (page * 10 > past.length){
+      if ($('.last-page')) return;
+
+      const $last = document.createElement('div');
+      $last.classList.add('last-page');
+      $last.innerText = '더 이상 데이터가 없습니다.';
+      $target.append($last);
+
+      return;
+    };
+
+    mountTenItmems(past)(page, $target);
+
+    sessionStorage.setItem('page', ++page);
+	}
+});
+
+const mountTenItmems = past => async (page, $target) => {
+    
+  // 로딩 컴포넌트 mount
+  if(!$('#Loading'))  $target.append(Loading());
+
+  // 요청갯수 확인
+  const requestMaxLength = past.length;
+  const rocket_img_urls = []; 
+  for (let i = (page - 1) * 10; i < page * 10; i++ ) {
+    if (requestMaxLength <= i) break;
+
+    const rocket_img_url = getRocketImg(past[i].rocket);
+    rocket_img_urls.push(rocket_img_url);
+  }
+
+  // 결합 하는 부분
+  const prepared_rocket_img_urls = await Promise.allSettled(rocket_img_urls); 
+  prepared_rocket_img_urls.forEach((obj, i) => { 
+    past[(page - 1) * 10 + i].rocket_img = obj.value;
+  });
+
+  // cards 컴포넌트 만드는 부분
+  let cards = [];
+  for (let i = (page - 1) * 10; i < page * 10; i++) {
+    cards.push(Card(past[i]));
+  }
+
+  // 로딩 컴포넌트 unmount
+  if ($('#Loading')) $('#Loading').remove();
+
+  // mount 하는 부분
+  $target.append(...cards);
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -201,8 +201,11 @@ header > nav > ul > li > a {
   right: 20px;
   width: 50px;
   height: 50px;
-
+  
   transform:rotate(-90deg);
+}
+#Arrow img:hover {
+  cursor: pointer;
 }
 /* -------- Loading --------- */
 #Loading {
@@ -242,4 +245,9 @@ header > nav > ul > li > a {
   to{
       transform: translateY(0);
   }
+}
+
+/* -------- last-page --------- */
+.last-page {
+  color: rgb(157, 150, 150);
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -250,4 +250,5 @@ header > nav > ul > li > a {
 /* -------- last-page --------- */
 .last-page {
   color: rgb(157, 150, 150);
+  margin: 20px 0;
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,8 +1,16 @@
+export const BASE_URL = 'https://api.spacexdata.com';
+
 export const get = async url => {
   const response = await fetch(url);
+
   if (!response.ok) {
     alert('에러가 발생했습니다.');
     console.error('에러가 발생했습니다.');
   }
+  
   return response.json();
+}
+export const getRocketImg = async id => {
+  return get(`${ BASE_URL }/v4/rockets/` + id)  
+    .then(res => res.flickr_images[1]);
 }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,1 +1,9 @@
 export const $ = selector => document.querySelector(selector);
+
+export const appendLastMent = $target => {
+  if ($('.last-page')) return;
+  const $last = document.createElement('div');
+  $last.classList.add('last-page');
+  $last.innerText = '더 이상 데이터가 없습니다.';
+  $target.append($last);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,16 @@
+import { $ } from './dom.js';
+
+export const isItLast = (page, arr) => {
+  if (page * 10 > arr.length) return true;
+}
+export const isItRightPage = selector => {
+  if ($(selector)) return true;
+  return false;
+}
+export const isItBottom = () => {
+	const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
+
+  if (scrollTop + clientHeight > scrollHeight - 1) return true;
+
+  return false;
+}


### PR DESCRIPTION
# Implementations

- 무한 스크롤 
- api 요청 중복 제거

### 요청(1) -> 요청 완료 -> 요청(2) -> 요청 완료 -> 요청(3) ...ing
> 약 200개의 요청에 대해 약 **40**초 소요

### Promise.allSettled로 병렬처리 
> 약 200개의 요청에 대해 약 **3.3**초 소요

### 무한스크롤로 초기 10개의 데이터만 요청
> 10개의 데이터  요청에 대해  약 **1.5초** 소요

# ScreenShoots
무한 스크롤
<img width='80%' src='https://user-images.githubusercontent.com/87258182/191226598-caeef577-d7a0-4a13-9ab7-90b726fb4a46.gif'>

 병렬처리
<img width="80%" alt="스크린샷 2022-09-19 오후 3 58 03" src="https://user-images.githubusercontent.com/87258182/191224186-086818b4-3aae-42e0-98d4-aae6b1afa646.png">

10개 응답
<img width="80%" alt="스크린샷 2022-09-19 오후 4 00 48" src="https://user-images.githubusercontent.com/87258182/191223871-b13a334f-5ded-4036-893d-487bf33442e3.png">
